### PR TITLE
Upgrade Solidity to 0.4.19 and Downgrade bignumber.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ build_webpack
 .DS_Store
 .env
 npm-debug.log
+yarn-error.log
 .truffle-solidity-loader

--- a/contracts/DebtKernel.sol
+++ b/contracts/DebtKernel.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "./DebtToken.sol";
 import "./TokenTransferProxy.sol";

--- a/contracts/DebtRegistry.sol
+++ b/contracts/DebtRegistry.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "./libraries/PermissionsLib.sol";
 import "zeppelin-solidity/contracts/math/SafeMath.sol";

--- a/contracts/DebtToken.sol
+++ b/contracts/DebtToken.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "./DebtRegistry.sol";
 import "NonFungibleToken/contracts/MintableNonFungibleToken.sol";

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 
 contract Migrations {

--- a/contracts/RepaymentRouter.sol
+++ b/contracts/RepaymentRouter.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "./DebtRegistry.sol";
 import "./TermsContract.sol";

--- a/contracts/TermsContract.sol
+++ b/contracts/TermsContract.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 
 interface TermsContract {

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 

--- a/contracts/TokenTransferProxy.sol
+++ b/contracts/TokenTransferProxy.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "./DebtRegistry.sol";
 import "zeppelin-solidity/contracts/lifecycle/Pausable.sol";

--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
 import "../DebtRegistry.sol";

--- a/contracts/examples/TermsContractRegistry.sol
+++ b/contracts/examples/TermsContractRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 
 contract TermsContractRegistry {

--- a/contracts/libraries/PermissionsLib.sol
+++ b/contracts/libraries/PermissionsLib.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 
 library PermissionsLib {

--- a/contracts/test/DummyContract.sol
+++ b/contracts/test/DummyContract.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "../libraries/PermissionsLib.sol";
 

--- a/contracts/test/dummy_tokens/DummyToken.sol
+++ b/contracts/test/dummy_tokens/DummyToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "zeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
 import "zeppelin-solidity/contracts/math/SafeMath.sol";

--- a/contracts/test/mocks/MockContract.sol
+++ b/contracts/test/mocks/MockContract.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 
 contract MockContract {

--- a/contracts/test/mocks/MockDebtRegsitry.sol
+++ b/contracts/test/mocks/MockDebtRegsitry.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "./MockContract.sol";
 

--- a/contracts/test/mocks/MockDebtToken.sol
+++ b/contracts/test/mocks/MockDebtToken.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "./MockContract.sol";
 import "zeppelin-solidity/contracts/token/ERC20/ERC20.sol";

--- a/contracts/test/mocks/MockERC20Token.sol
+++ b/contracts/test/mocks/MockERC20Token.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "./MockContract.sol";
 import "zeppelin-solidity/contracts/token/ERC20/ERC20.sol";

--- a/contracts/test/mocks/MockERC721Token.sol
+++ b/contracts/test/mocks/MockERC721Token.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "./MockContract.sol";
 

--- a/contracts/test/mocks/MockTermsContract.sol
+++ b/contracts/test/mocks/MockTermsContract.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "./MockContract.sol";
 

--- a/contracts/test/mocks/MockTokenTransferProxy.sol
+++ b/contracts/test/mocks/MockTokenTransferProxy.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.18;
+pragma solidity 0.4.19;
 
 import "./MockContract.sol";
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@dharmaprotocol/dharma.js": "^0.0.11",
     "NonFungibleToken": "https://github.com/dharmaprotocol/NonFungibleToken",
-    "bignumber.js": "^6.0.0",
+    "bignumber.js": "^5.0.0",
     "bootstrap": "^4.0.0",
     "dotenv": "^2.0.0",
     "ganache-cli": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,10 +1273,6 @@ bignumber.js@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-5.0.0.tgz#fbce63f09776b3000a83185badcde525daf34833"
 
-bignumber.js@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-6.0.0.tgz#bbfa047644609a5af093e9cbd83b0461fa3f6002"
-
 "bignumber.js@git+https://github.com/debris/bignumber.js#master":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js#c7a38de919ed75e6fb6ba38051986e294b328df9"


### PR DESCRIPTION
## Description
#### `trunc` method is removed in `bignumber.js` `v6.0.0`
See [bignumber.js CHANGELOG.md](https://github.com/MikeMcl/bignumber.js/blob/33e7d0a7cbb9bcd3d3e395d8efe46af17a73da66/CHANGELOG.md)